### PR TITLE
Change tsplot to lineplot

### DIFF
--- a/nideconv/plotting.py
+++ b/nideconv/plotting.py
@@ -38,11 +38,10 @@ def plot_timecourses(tc,
                             aspect=aspect,
                             col_order=col_order)
 
-        fac.map_dataframe(sns.tsplot,
-                          time='time',
-                          unit='subject',
-                          condition=hue,
-                          value='value',
+        fac.map_dataframe(sns.lineplot,
+                          x='time',
+                          hue=hue,
+                          y='value',
                           color=sns.color_palette(),
                           *args,
                           **kwargs)


### PR DESCRIPTION
Changed the use of `tsplot` to `lineplot` as `tsplot` will be deprecated.
(Gets rid of annoying warning.)

Only issue is that `lineplot` does not have the `unit` parameters;
no clue whether that messes up something in multisubject analyses.