### PR TITLE
Make Python3 proof

### DIFF
--- a/nideconv/regressors.py
+++ b/nideconv/regressors.py
@@ -236,7 +236,7 @@ class Event(Regressor):
         else:
             self.covariates = pd.DataFrame(covariates)
 
-        if type(self.basis_set) not in [unicode,str]:
+        if not isinstance(self.basis_set, str):
             self.n_regressors = self.basis_set.shape[1]
 
             self.basis_set = pd.DataFrame(self.basis_set,
@@ -379,7 +379,7 @@ class Event(Regressor):
 
 
         # only for fir, the nr of regressors is dictated by the interval and sample rate
-        if type(self.basis_set) in [unicode,str]:
+        if isinstance(self.basis_set, str):
 
             if self.basis_set == 'fir':
                 L = _create_fir_basis(self.interval, self.sample_rate, self.n_regressors, oversample)


### PR DESCRIPTION
Removed references to `unicode` (Python2 syntax) as it breaks Python3 scripts. Alternatively, to make it python2 compatible (but why would you?), you could add something like the following to the start of `regressors.py`:

```python
import sys
if sys.version_info[0] >= 3:
    unicode = str
```