### PR TITLE
ev.index has no method get_values()

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ nideconv is a Python module for fast and easy estimating of event-related signal
 # Installation
 Currently, nideconv can be installed using the GitHub repository:
 
-### Make Conda environment (optional but highly reccomended, especially for Windows)
+### Make Conda environment (optional but highly recomended, especially for Windows)
 I highly recommend to first make a dedicated [Anaconda/Miniconda](https://docs.conda.io/en/latest/miniconda.html)-environment:
 
 `conda create --name nideconv`

--- a/nideconv/group_analysis.py
+++ b/nideconv/group_analysis.py
@@ -128,6 +128,7 @@ class GroupResponseFitter(object):
                   n_regressors=None,
                   covariates=None,
                   add_intercept=True,
+                  show_warnings=True
                   **kwargs):
 
         if not hasattr(self, 'events'):
@@ -135,7 +136,8 @@ class GroupResponseFitter(object):
 
         if event is None:
             event = self.onsets.index.get_level_values('event_type').unique()
-            logging.warning(
+            if show_warnings:
+                logging.warning(
                 'No event type was given, automatically entering the following event types: %s' % event.tolist())
 
         if type(event) is str:
@@ -154,7 +156,8 @@ class GroupResponseFitter(object):
                     col = (col,)
 
                 if col + (e,) not in self.onsets.index:
-                    warnings.warn('Event %s is not available for run %s. Event is ignored for this '
+                    if show_warnings:
+                        warnings.warn('Event %s is not available for run %s. Event is ignored for this '
                                   'run' % (e, col))
                 else:
 

--- a/nideconv/group_analysis.py
+++ b/nideconv/group_analysis.py
@@ -128,7 +128,7 @@ class GroupResponseFitter(object):
                   n_regressors=None,
                   covariates=None,
                   add_intercept=True,
-                  show_warnings=True
+                  show_warnings=True,
                   **kwargs):
 
         if not hasattr(self, 'events'):

--- a/nideconv/response_fitter.py
+++ b/nideconv/response_fitter.py
@@ -294,9 +294,9 @@ class ResponseFitter(object):
         for event_type, event in self.events.items():
             for covariate in event.covariates.columns:
                 ev = event.get_basis_function(oversample=oversample)
-                ev.index = pd.MultiIndex.from_product([[event_type], [covariate], ev.index.get_values()],
+                ev.index = pd.MultiIndex.from_product([[event_type], [covariate], ev.index],
                                                       names=names)
-                ev.columns = pd.MultiIndex.from_product([[event_type], [covariate], ev.columns.get_values()],
+                ev.columns = pd.MultiIndex.from_product([[event_type], [covariate], ev.columns],
                                                         names=['event type', 'covariate', 'regressor'])
                 bf = pd.concat((bf, ev), axis=0, )
 


### PR DESCRIPTION
1) ev.index has no method get_values()
2) keyword option to suppress warnings when doing group analyses. Particularly useful when wanting to fit a single event per run (corner case, I know ;-) )
+ minor readme fix