### PR TITLE
Raise an error for incorrect keyword input "type"

### DIFF
--- a/nideconv/response_fitter.py
+++ b/nideconv/response_fitter.py
@@ -174,6 +174,10 @@ class ResponseFitter(object):
                     'No support for multidimensional signals yet')
             self.ridge_regress(cv=cv, alphas=alphas,
                                store_residuals=store_residuals)
+        
+        else:
+            raise NotImplementedError(
+                f'No support for "{type}" type of fit (yet)')
 
     def get_standard_errors_timecourse(self, melt=False, oversample=None):
         self._check_fitted()


### PR DESCRIPTION
If type of fit for method fit is misspelled or plain incorrect, no error is thrown. To avoid confusion later down the line, I'd propose it should throw an error here because I cannot imagine a use case where not throwing an error is beneficial.